### PR TITLE
Supported JMeter 5.4.2 & updated libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Pay attention on "Sending metrics performance tuning" chapter, see below.
 The supported versions:
 * Java 11 - make sure that you have it (its minimum version).
 * InfluxDB v2.0, see release notes: https://docs.influxdata.com/influxdb/v2.0/reference/release-notes/influxdb/  (1.8 is not supported)
-* JMeter 5.4.1 only.
+* JMeter 5.4.2 only.
 * The current board and plugin were tested on Grafana 8.2.3 and InfluxDB 2.0.9, JAVA 15.
 
 ## Deployment

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 sourceCompatibility = 11
-version = '1.3'
+version = '1.4'
 def title = 'JMeterInfluxDBListener'
 def archiveName = 'jmeter-plugin-influxdb2-listener'
 
@@ -31,11 +31,11 @@ def archiveName = 'jmeter-plugin-influxdb2-listener'
     }
 
     dependencies {
-        implementation group: 'org.apache.jmeter', name: 'ApacheJMeter_core', version: '5.4.1'
-        implementation group: 'org.apache.jmeter', name: 'ApacheJMeter_java', version: '5.4.1'
-        implementation group: 'org.apache.jmeter', name: 'ApacheJMeter_components', version: '5.4.1'
-        implementation group: 'org.apache.jmeter', name: 'jorphan', version: '5.4.1'
-        implementation group: 'com.influxdb', name: 'influxdb-client-java', version: '3.2.0'
+        implementation group: 'org.apache.jmeter', name: 'ApacheJMeter_core', version: '5.4.2'
+        implementation group: 'org.apache.jmeter', name: 'ApacheJMeter_java', version: '5.4.2'
+        implementation group: 'org.apache.jmeter', name: 'ApacheJMeter_components', version: '5.4.2'
+        implementation group: 'org.apache.jmeter', name: 'jorphan', version: '5.4.2'
+        implementation group: 'com.influxdb', name: 'influxdb-client-java', version: '4.0.0'
         implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
 
 

--- a/src/main/java/org/md/jmeter/influxdb2/visualizer/config/InfluxDBConfig.java
+++ b/src/main/java/org/md/jmeter/influxdb2/visualizer/config/InfluxDBConfig.java
@@ -1,6 +1,7 @@
 package org.md.jmeter.influxdb2.visualizer.config;
 
-import com.influxdb.Arguments;
+
+import com.influxdb.utils.Arguments;
 import org.apache.jmeter.visualizers.backend.BackendListenerContext;
 
 /**


### PR DESCRIPTION
Supported JMeter 5.4.2, & updated libs - > influxdb-client-java: 4.0.0 
Closes #30 