### PR TITLE
Implementation for influxdb url configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,7 @@ Let’s explain the plugin fields:
 * `testName` - the name of the test.
 * `nodeName` - the name of the server.
 * `runId` - the identification number of hte test run, can be dynamic.
-* `influxDBScheme` - InfluxDB server scheme (can be http or https).
-* `influxDBHost` - the host name or ip of the InfluxDB server.
-* `influxDBPort` - the port of the InfluxDB server, the default is 8086.
+* `influxDBURL` - InfluxDB server URL [protocol://][host][:port], protocol (can be http or https) and the default port is 8086.
 * `influxDBToken` - the influxdb bucket token, the default value should be updated, copy it from InfluxDB site.
 
   ![](img/influx3.png)

--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,11 @@ publishing {
                         name = 'Uladzislau Shklianik'
                         email = 'Uladzislau_Shklianik@epam.com'
                     }
+                    developer {
+                        id = 'MalshaUdani'
+                        name = 'Malsha Nagahawatta'
+                        email = 'malsha.nagahawatta@gmail.com'
+                    }
                 }
                 scm {
                     connection = 'scm:git:git:github.com/mderevyankoaqa/jmeter-influxdb2-listener-plugin.git'

--- a/src/main/java/io/github/mderevyankoaqa/influxdb2/visualizer/InfluxDatabaseBackendListenerClient.java
+++ b/src/main/java/io/github/mderevyankoaqa/influxdb2/visualizer/InfluxDatabaseBackendListenerClient.java
@@ -157,9 +157,7 @@ public class InfluxDatabaseBackendListenerClient extends AbstractBackendListener
         arguments.addArgument(KEY_TEST_NAME, "Test");
         arguments.addArgument(KEY_NODE_NAME, "Test-Node");
         arguments.addArgument(KEY_RUN_ID, "R001");
-        arguments.addArgument(InfluxDBConfig.KEY_HTTP_SCHEME, InfluxDBConfig.DEFAULT_HTTP_SCHEME);
-        arguments.addArgument(InfluxDBConfig.KEY_INFLUX_DB_HOST, "localhost");
-        arguments.addArgument(InfluxDBConfig.KEY_INFLUX_DB_PORT, Integer.toString(InfluxDBConfig.DEFAULT_PORT));
+        arguments.addArgument(InfluxDBConfig.KEY_INFLUX_DB_URL, InfluxDBConfig.DEFAULT_INFLUXDB_URL);
         arguments.addArgument(InfluxDBConfig.KEY_INFLUX_DB_TOKEN, InfluxDBConfig.DEFAULT_INFLUX_DB_TOKEN);
         arguments.addArgument(InfluxDBConfig.KEY_INFLUX_DB_ORG, InfluxDBConfig.DEFAULT_INFLUX_DB_ORG);
         arguments.addArgument(InfluxDBConfig.KEY_INFLUX_DB_BUCKET, InfluxDBConfig.DEFAULT_BUCKET);

--- a/src/main/java/io/github/mderevyankoaqa/influxdb2/visualizer/config/InfluxDBConfig.java
+++ b/src/main/java/io/github/mderevyankoaqa/influxdb2/visualizer/config/InfluxDBConfig.java
@@ -18,14 +18,9 @@ public class InfluxDBConfig {
     public static final String DEFAULT_BUCKET = "jmeter";
 
     /**
-     * Default http scheme name.
+     * Default influxdb url.
      */
-    public static final String DEFAULT_HTTP_SCHEME = "http";
-
-    /**
-     * Default port.
-     */
-    public static final int DEFAULT_PORT = 8086;
+    public static final String DEFAULT_INFLUXDB_URL = "http://localhost:8086/";
 
     /**
      * Default threshold error.
@@ -58,6 +53,11 @@ public class InfluxDBConfig {
     public static final int DEFAULT_RESPONSE_BODY_LENGTH = 2000;
 
     /**
+     * Config key for influxdb url.
+     */
+    public static final String KEY_INFLUX_DB_URL = "influxDBURL";
+
+    /**
      * Config key for bucket.
      */
     public static final String KEY_INFLUX_DB_BUCKET = "influxDBBucket";
@@ -71,21 +71,6 @@ public class InfluxDBConfig {
      * Config key for token.
      */
     public static final String KEY_INFLUX_DB_TOKEN = "influxDBToken";
-
-    /**
-     * Config key for port.
-     */
-    public static final String KEY_INFLUX_DB_PORT = "influxDBPort";
-
-    /**
-     * Config key for host.
-     */
-    public static final String KEY_INFLUX_DB_HOST = "influxDBHost";
-
-    /**
-     * Config key for http scheme.
-     */
-    public static final String KEY_HTTP_SCHEME = "influxDBHttpScheme";
 
     /**
      * Config key for batch size.
@@ -108,9 +93,9 @@ public class InfluxDBConfig {
     public static final String KEY_RESPONSE_BODY_LENGTH = "responseBodyLength";
 
     /**
-     * InfluxDB Host.
+     * InfluxDB URL.
      */
-    private String influxDBHost;
+    private String influxDBURL;
 
     /**
      * InfluxDB Token.
@@ -126,16 +111,6 @@ public class InfluxDBConfig {
      * InfluxDB database Bucket.
      */
     private String influxBucket;
-
-    /**
-     * InfluxDB Port.
-     */
-    private int influxDBPort;
-
-    /**
-     * InfluxDB database retention policy.
-     */
-    private String influxHTTPScheme;
 
     /**
      * InfluxDB database batch size.
@@ -163,12 +138,11 @@ public class InfluxDBConfig {
      * @param context the {@link BackendListenerContext}
      */
     public InfluxDBConfig(BackendListenerContext context) {
-        String influxDBHost = context.getParameter(KEY_INFLUX_DB_HOST);
-        Arguments.checkNonEmpty(KEY_INFLUX_DB_BUCKET, influxDBHost);
-        this.setInfluxDBHost(influxDBHost);
-
-        int influxDBPort = context.getIntParameter(KEY_INFLUX_DB_PORT, InfluxDBConfig.DEFAULT_PORT);
-        this.setInfluxDBPort(influxDBPort);
+        String influxDBURL = context.getParameter(KEY_INFLUX_DB_URL);
+        Arguments.checkNonEmpty(influxDBURL, KEY_INFLUX_DB_URL);
+        String[] influxHTTPScheme =  influxDBURL.split("://",2);
+        ArgsValidator.checkHTTPScheme(influxHTTPScheme[0]);
+        this.setInfluxDBURL(influxDBURL);
 
         String influxToken = context.getParameter(KEY_INFLUX_DB_TOKEN);
         Arguments.checkNonEmpty(influxToken, KEY_INFLUX_DB_TOKEN);
@@ -181,9 +155,6 @@ public class InfluxDBConfig {
         String influxBucket = context.getParameter(KEY_INFLUX_DB_BUCKET);
         Arguments.checkNonEmpty(influxBucket, KEY_INFLUX_DB_BUCKET);
         this.setInfluxBucket(influxBucket);
-
-        String influxHTTPScheme = ArgsValidator.checkHTTPScheme(context.getParameter(KEY_HTTP_SCHEME, DEFAULT_HTTP_SCHEME));
-        this.setInfluxHTTPScheme(influxHTTPScheme);
 
         int influxdbBatchSize = context.getIntParameter(KEY_INFLUX_DB_MAX_BATCH_SIZE);
         Arguments.checkNotNegativeNumber(influxdbBatchSize, KEY_INFLUX_DB_MAX_BATCH_SIZE);
@@ -203,30 +174,21 @@ public class InfluxDBConfig {
     }
 
     /**
-     * Builds URL to influxDB.
+     * Gets the InfluxDB URL.
      *
-     * @return influxDB URL.
+     * @return the InfluxDB URL.
      */
     public String getInfluxDBURL() {
-        return this.influxHTTPScheme + "://" + this.getInfluxDBHost() + ":" + this.getInfluxDBPort();
+        return influxDBURL;
     }
 
     /**
-     * Gets the influxDBHost.
+     * Sets influxDB URL.
      *
-     * @return the influxDBHost.
+     * @param influxDBURL the influxdb host url.
      */
-    public String getInfluxDBHost() {
-        return this.influxDBHost;
-    }
-
-    /**
-     * Sets influxDBHost.
-     *
-     * @param influxDBHost the influxDBHost to set.
-     */
-    public void setInfluxDBHost(String influxDBHost) {
-        this.influxDBHost = influxDBHost;
+    public void setInfluxDBURL(String influxDBURL) {
+        this.influxDBURL = influxDBURL;
     }
 
     /**
@@ -245,33 +207,6 @@ public class InfluxDBConfig {
      */
     public void setInfluxBucket(String influxBucket) {
         this.influxBucket = influxBucket;
-    }
-
-    /**
-     * Sets influxHTTPScheme.
-     *
-     * @param influxHTTPScheme the influxHTTPScheme to set.
-     */
-    public void setInfluxHTTPScheme(String influxHTTPScheme) {
-        this.influxHTTPScheme = influxHTTPScheme;
-    }
-
-    /**
-     * Gets influxDBPort.
-     *
-     * @return the influxDBPort.
-     */
-    public int getInfluxDBPort() {
-        return this.influxDBPort;
-    }
-
-    /**
-     * Sets setInfluxDBPort.
-     *
-     * @param influxDBPort the influxDBPort to set.
-     */
-    public void setInfluxDBPort(int influxDBPort) {
-        this.influxDBPort = influxDBPort;
     }
 
     /**


### PR DESCRIPTION
Fix for: https://github.com/mderevyankoaqa/jmeter-influxdb2-listener-plugin/issues/74

This change will allow user to send influxdb url through single configuration parameter which will resolve issue in building influxdb url with different url components (example: context path). 