### PR TITLE
Fix wrong classname references in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Note: "fatJar" gradle task should be used to create the package for the JMeter.
 
   ![](img/testPlan.png)
 
-* Select from the dropdown item with the name '`io.github.mderevyankoaqa.influxdb2.visualizer.JMeterInfluxDBBackendListenerClient`'.
+* Select from the dropdown item with the name '`io.github.mderevyankoaqa.influxdb2.visualizer.InfluxDatabaseBackendListenerClient`'.
 
   ![](img/deploy3.png)
 
@@ -124,7 +124,7 @@ Note: "fatJar" gradle task should be used to create the package for the JMeter.
 * Remove old jar.
 * Put '`jmeter-plugin-influxdb2-listener-<version>.jar`' file from [Releases](https://github.com/mderevyankoaqa/jmeter-influxdb2-listener-plugin/releases) to `~<JmeterPath<\lib\ext`;
 * Run JMeter again and got Listener.
-* Select from the dropdown item with the name '`io.github.mderevyankoaqa.influxdb2.visualizer.JMeterInfluxDBBackendListenerClient`'.
+* Select from the dropdown item with the name '`io.github.mderevyankoaqa.influxdb2.visualizer.InfluxDatabaseBackendListenerClient`'.
 
   ![](img/deploy3.png)
 


### PR DESCRIPTION
The correct classname is io.github.mderevyankoaqa.influxdb2.visualizer.InfluxDatabaseBackendListenerClient as already shown in the screenshot.