### PR TITLE
Recursive subsampling fix - Bug 111

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 
 sourceCompatibility = 11
 group = 'io.github.mderevyankoaqa'
-version = '2.8'
+version = '2.8-rhill-custom'
 
 def title = 'JMeterInfluxDB2Listener'
 def archiveName = 'jmeter-plugins-influxdb2-listener'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 
 sourceCompatibility = 11
 group = 'io.github.mderevyankoaqa'
-version = '2.8-rhill-custom'
+version = '2.8.1-recursive-subsample-patch'
 
 def title = 'JMeterInfluxDB2Listener'
 def archiveName = 'jmeter-plugins-influxdb2-listener'


### PR DESCRIPTION
Hi,
This resolves bug: https://github.com/mderevyankoaqa/jmeter-influxdb2-listener-plugin/issues/111

Technical Summary: JMeter-InfluxDB2-Listener (Recursive Fix)

**Problem Statement:**
The original plugin (v2.8) utilized a "shallow" discovery method for sub-samples. When using complex logic controllers like the bzm - Parallel Controller, the plugin could only see one level deep. This resulted in "blind spots" where actual HTTP requests (grandchild nodes) were hidden from InfluxDB, while only the parent controller was recorded.

**Key Improvements:**

- Recursive Sub-sample Flattening: Replaced the standard Collections.addAll logic with a custom recursive method addSampleAndAllSubSamples. This ensures that no matter how deep a request is nested (e.g., Transaction -> Parallel Controller -> Loop -> HTTP Request), it is captured and sent to InfluxDB.

- Collision Prevention: Maintained the use of a high-precision timestamp combined with a SecureRandom nanosecond jitter. This prevents data overwriting in InfluxDB when multiple parallel requests finish at the exact same millisecond.

**Logical Workflow Comparison:**
**Original (v2.8)**

- Search Depth - Limited (1 Level)
- Nested Controller Support (e.g. Parallel) - Partial (Misses children)

**Updated (2.8.1-recursive-subsample-patch)**
- Search Depth - Infinite (Recursive)
- Nested Controller Support (e.g. Parallel) - Full Support


///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
**In JMeter:**
If you don't want the nested controllers (e.g. Parallel) to end up in Grafana, you can filter them out (like I do).

In Listener samplersList, add the following regex: ^(?!.*bzm - Parallel Controller).*$ 
<img width="1121" height="126" alt="image" src="https://github.com/user-attachments/assets/d9b6c427-c55d-4f1e-9b62-7370feaceae0" />

This will stop ‘bzm - Parallel Controller’ being sent to InfluxDB2
Outcome should be that:

- Transactions are sent
- Transaction child http request are sent
- bzm - Parallel Controller child http requests are sent
- bzm - Parallel Controller is NOT sent